### PR TITLE
build: add std_srvs as missing dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,27 +3,27 @@ project(ipcamera_driver)
 
 
 find_package(catkin REQUIRED COMPONENTS
-  std_srvs
   camera_info_manager
   cv_bridge
   dynamic_reconfigure
   image_transport
   roscpp
   sensor_msgs
+  std_srvs
 )
 
 find_package( OpenCV REQUIRED )
 include_directories(include ${catkin_INCLUDE_DIRS}  ${OpenCV_INCLUDE_DIRS} )
 catkin_package(
  CATKIN_DEPENDS
-  std_srvs
   camera_info_manager
   cv_bridge
   dynamic_reconfigure
   image_transport
   roscpp
   sensor_msgs
- DEPENDS
+  std_srvs
+DEPENDS
   OpenCV
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(ipcamera_driver)
 
 
 find_package(catkin REQUIRED COMPONENTS
+  std_srvs
   camera_info_manager
   cv_bridge
   dynamic_reconfigure
@@ -15,6 +16,7 @@ find_package( OpenCV REQUIRED )
 include_directories(include ${catkin_INCLUDE_DIRS}  ${OpenCV_INCLUDE_DIRS} )
 catkin_package(
  CATKIN_DEPENDS
+  std_srvs
   camera_info_manager
   cv_bridge
   dynamic_reconfigure

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- build dependencies -->
+  <build_depend>std_srvs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
@@ -27,6 +28,7 @@
   <build_depend>camera_info_manager</build_depend>
 
   <!-- runtime dependencies -->
+  <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>


### PR DESCRIPTION
See title.
Used here: 

https://github.com/alireza-hosseini/ipcamera_driver/blob/118fffba1674c8d5f1090aa7656452ebf87a4cd5/src/ipcamera_driver.cpp#L111